### PR TITLE
add tab separated txt read_df

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ env
 .idea
 .vscode
 __pycache__
+.DS_Store

--- a/iwutil/__init__.py
+++ b/iwutil/__init__.py
@@ -152,6 +152,10 @@ def iwutil_file_path_helper(file_name: str | Path, **kwargs):
         return pd.read_json(file_name, **kwargs)
     elif file_extension == "parquet":
         return pd.read_parquet(file_name, **kwargs)
+    elif file_extension == "txt":
+        if "sep" not in kwargs:
+            kwargs["sep"] = "\t"
+        return pd.read_csv(file_name, **kwargs)
     else:
         raise ValueError(f"Unsupported file type: {file_extension}")
 

--- a/iwutil/save.py
+++ b/iwutil/save.py
@@ -60,6 +60,21 @@ def parquet(df, filename):
     df.to_parquet(filename)
 
 
+def txt(df, filename):
+    """
+    Save df to a txt file
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame to save
+    filename : str
+        Full path and name of the file to save
+    """
+    create_folder(filename)
+    df.to_csv(filename, index=False, sep="\t")
+
+
 def fig(fig_to_save, filename):
     """
     Save fig to a file

--- a/tests/test_save_read.py
+++ b/tests/test_save_read.py
@@ -5,7 +5,7 @@ import pytest
 import pathlib
 
 
-@pytest.mark.parametrize("file_format", ["df", "csv", "parquet", "json", "csv"])
+@pytest.mark.parametrize("file_format", ["df", "csv", "parquet", "json", "txt"])
 @pytest.mark.parametrize("path_format", ["posix path", "str"])
 def test_save_read_df(file_format, path_format):
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
@@ -29,6 +29,8 @@ def test_save_read_df(file_format, path_format):
                 iwutil.save.parquet(df, file)
             elif file_format == "json":
                 iwutil.save.json(df.to_dict(orient="list"), file)
+            elif file_format == "txt":
+                iwutil.save.txt(df, file)
             else:
                 raise NotImplementedError(f"Test does not cover format: {file_format}")
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for reading and writing tab-separated `.txt` files in the `iwutil` module.
> 
>   - **Behavior**:
>     - Add support for reading `.txt` files with tab separation in `iwutil_file_path_helper()` in `iwutil/__init__.py`.
>     - Add `txt()` function in `iwutil/save.py` to save DataFrames as tab-separated `.txt` files.
>   - **Tests**:
>     - Update `test_save_read_df()` in `tests/test_save_read.py` to include `.txt` format.
>     - Add `.txt` format to `pytest.mark.parametrize` in `tests/test_save_read.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ionworks%2Fiwutil&utm_source=github&utm_medium=referral)<sup> for 68630a1f0322ca95cd6f7a457a7995b1ac3550c3. You can [customize](https://app.ellipsis.dev/ionworks/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->