### PR TITLE
Setup sphinx docs and ReadTheDocs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,35 @@
+name: Build documentation
+
+on:
+  pull_request:
+    branches:
+      - "main"
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+  html:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install ".[dev]"
+
+      - name: Build documentation
+        run: |
+          cd docs
+          make html SPHINXOPTS="-W --keep-going"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 _version.py
 *.egg-info
 .DS_Store
+_build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+version: 2
+
+submodules:
+  include: all
+  recursive: true
+
+formats:
+  - pdf
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.12"
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev
+
+sphinx:
+  configuration: docs/conf.py

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ extensions = [
 myst_dmath_double_inline = True
 templates_path = ["_templates"]
 source_suffix = [".rst", ".md"]
-master_doc = "index"
+root_doc = "index"
 language = "en"
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import iwutil as iu
+
+# Path for repository root
+sys.path.insert(0, os.path.abspath("../"))
+
+# -- Project information -----------------------------------------------------
+
+project = "Ionworks Utility Functions"
+copyright = "2025, Ionworks Technologies Inc"
+author = "Ionworks Technologies Inc"
+
+# Note: Both version and release are used in the build
+version = iu.__version__
+release = iu.__version__
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    'myst_parser',
+    'sphinx.ext.autodoc',
+]
+myst_dmath_double_inline = True
+templates_path = ["_templates"]
+source_suffix = [".rst", ".md"]
+master_doc = "index"
+language = "en"
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- Options for HTML output -------------------------------------------------
+
+html_theme = "sphinx_rtd_theme"
+html_permalinks_icon = "<span>¶</span>"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,11 @@
+##########################
+Ionworks utility functions
+##########################
+
+Public utility functions for Ionworks software
+
+.. toctree::
+    :hidden:
+    :maxdepth: 2
+
+    source/api/index

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -1,4 +1,4 @@
-.. module:: iwutils
+.. module:: iwutil
 
 .. _api_docs:
 

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -1,0 +1,45 @@
+.. module:: iwutils
+
+.. _api_docs:
+
+#################
+API documentation
+#################
+
+.. autoclass:: iwutil.OptionSpec
+
+.. autofunction:: iwutil.subplots_autolayout
+
+.. autofunction:: iwutil.check_and_combine_options
+
+.. autofunction:: iwutil.read_df
+
+.. autofunction:: iwutil.iwutil_file_path_helper
+
+.. autofunction:: iwutil.read_json
+
+.. autofunction:: iwutil.copyfile
+
+.. autofunction:: iwutil.this_dir
+
+.. autofunction:: iwutil.append_path
+
+.. autofunction:: iwutil.random.current_time_integer
+
+.. autofunction:: iwutil.random.generate_seed
+
+.. autofunction:: iwutil.random.seed
+
+.. autofunction:: iwutil.random.get_seed
+
+.. autofunction:: iwutil.save.create_folder
+
+.. autofunction:: iwutil.save.json
+
+.. autofunction:: iwutil.save.csv
+
+.. autofunction:: iwutil.save.parquet
+
+.. autofunction:: iwutil.save.txt
+
+.. autofunction:: iwutil.save.fig

--- a/iwutil/__init__.py
+++ b/iwutil/__init__.py
@@ -64,10 +64,12 @@ def check_and_combine_options(default_options, custom_options=None):
     default_options : dict
         Dictionary of default options. Each key is an option name, and the value can be
         either:
+
         - The default value for that option
         - "[required]" if the option must be provided in custom_options
         - A list of allowed values for that option. If the option is not provided in
           custom_options, the first value in the list is used.
+          
     custom_options : dict, optional
         Dictionary of custom options, by default None. If a key in custom_options is not
         in default_options, an error is raised.
@@ -122,7 +124,7 @@ def read_df(file, **kwargs):
     ----------
     file : str or Path
         File to read
-    **kwargs : dict
+    `**kwargs` : dict
         Additional keyword arguments to pass to the read function
     """
     raise NotImplementedError(f"Reading type {type(file)} not implemented")

--- a/iwutil/__init__.py
+++ b/iwutil/__init__.py
@@ -14,7 +14,7 @@ def subplots_autolayout(
     n, *args, n_rows=None, figsize=None, layout="constrained", **kwargs
 ):
     """
-    Create a subplot element with a
+    Create a subplot element
     """
     n_rows = n_rows or int(n // np.sqrt(n))
     n_cols = int(np.ceil(n / n_rows))
@@ -114,7 +114,7 @@ def check_and_combine_options(default_options, custom_options=None):
 @singledispatch
 def read_df(file, **kwargs):
     """
-    Read a dataframe from a file. Currently supports csv, xls, xlsx, json, and parquet.
+    Read a dataframe from a file. Currently: supports csv, xls, xlsx, json, and parquet.
 
     Parameters
     ----------

--- a/iwutil/__init__.py
+++ b/iwutil/__init__.py
@@ -9,6 +9,8 @@ import shutil
 import sys
 import json
 
+from iwutil._version import __version__
+
 
 def subplots_autolayout(
     n, *args, n_rows=None, figsize=None, layout="constrained", **kwargs

--- a/iwutil/random.py
+++ b/iwutil/random.py
@@ -35,4 +35,4 @@ def get_seed() -> int:
     """
     Get the random seed for numpy.
     """
-    return np.random.get_state()[1][0]
+    return int(np.random.get_state()[1][0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "sphinx_rtd_theme",
+    "sphinx",
+    "myst-parser",
 ]
 
 [project.urls]


### PR DESCRIPTION
First pass at adding documentation
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set up Sphinx documentation and integrate with ReadTheDocs, including GitHub Actions workflow and necessary configuration files.
> 
>   - **Documentation Setup**:
>     - Adds `.github/workflows/build_docs.yml` to build documentation on pull requests to `main`.
>     - Adds `.readthedocs.yaml` for ReadTheDocs configuration, specifying Python 3.12 and PDF format.
>     - Adds `docs/Makefile` and `docs/make.bat` for Sphinx documentation building.
>     - Adds `docs/conf.py` for Sphinx configuration, using `sphinx_rtd_theme` and `myst_parser`.
>     - Adds `docs/index.rst` and `docs/source/api/index.rst` for documentation structure and API reference.
>   - **Dependencies**:
>     - Updates `pyproject.toml` to include `sphinx`, `sphinx_rtd_theme`, and `myst-parser` in `dev` dependencies.
>   - **Misc**:
>     - Adds `__version__` import in `iwutil/__init__.py` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ionworks%2Fiwutil&utm_source=github&utm_medium=referral)<sup> for 0c6a5c700db5da974a9999dd256a2e2438a0faf7. You can [customize](https://app.ellipsis.dev/ionworks/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->